### PR TITLE
Query Ensembl GRCh37 v93 instead of v75

### DIFF
--- a/makeLUTs/create_genes_dictionary.py
+++ b/makeLUTs/create_genes_dictionary.py
@@ -19,7 +19,7 @@ def build_ensembl_genes():
     '''
 
     #connect to Ensembl MySQL public server
-    core = create_engine('mysql+mysqldb://anonymous@ensembldb.ensembl.org:3337/homo_sapiens_core_92_37')
+    core = create_engine('mysql+mysqldb://anonymous@ensembldb.ensembl.org:3337/homo_sapiens_core_93_37')
 
     q = """
     select


### PR DESCRIPTION
I've changed it to use v93.

In the query, `r.coord_system_id = 4` was returning 0 rows. Looking at what these ID's correspond to:

```
coord_system_id	species_id	name	version	rank	attrib
1	1	contig		4	default_version,sequence_level
2	1	chromosome	GRCh37	1	default_version
3	1	supercontig	GRCh37	2	default_version
4	1	clone		3	default_version
27	1	chromosome	NCBI36	5	
101	1	chromosome	NCBI35	6	
1001	1	chromosome	NCBI34	7	
1004	1	lrg		8	default_version
10004	1	chromosome	GRCh38	9
```

`r.coord_system_id = 4` is for "clones". I'm not sure what the reason behind this option was. I have changed this to `r.coord_system_id = 2`, which returns rows, as expected.

Other changes are:
  i. it returns a flattened list of exon positions. This is not pre-sorted, so genes on the reverse strand will have exons in the reverse order.
  ii. only keeps valid chromosomes
