### PR TITLE
Set description to be "" rather than null for genes with no description

### DIFF
--- a/makeLUTs/create_genes_dictionary.py
+++ b/makeLUTs/create_genes_dictionary.py
@@ -47,7 +47,7 @@ def build_ensembl_genes(pipeline_file_name, enable_platform_mode, ensembl_databa
     et.transcript_id,
     g.stable_id AS gene_id,
     x.display_label AS gene_name,
-    g.description,
+    IFNULL(g.description, "") AS description,
     g.biotype,
     g.source,
     g.version,


### PR DESCRIPTION
Some genes (generally from less-common biotypes) have no descriptions. This change makes the description be the empty string rather than null, to prevent downstream problems.

Checking with `jq '.[] | select (.id == "ENSG00000238933") | .description'` gave `null` before, now gives `""`