### PR TITLE
Fix/update versions es ch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-
+.idea/
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/README.md
+++ b/README.md
@@ -71,10 +71,8 @@ You can use wget to download the release data. Below is an example of the comman
 | Date | Name | Version | 
 | --- | --- | --- | 
 | 11/6/20 | ElasticSearch | [7.7.1](https://www.elastic.co/guide/en/elasticsearch/reference/7.7/getting-started-install.html) |
-| 11/6/20 | ClickHouse | [20.1.4](https://clickhouse.tech/docs/en/) |
+| 11/6/20 | ClickHouse | [20.4.5.36](https://clickhouse.tech/docs/en/) |
  
-
-
 Clickhouse is currently used by the Genetics Platform and API. A number of [scripts](gcp/clickhouse) are provided to 
 create and configure VM instances. 
 
@@ -87,6 +85,10 @@ create and configure VM instances.
 
 - Create the machine with this [script](gcp/create_clickhouse_node_es.sh). It automatically calls a [startup script](gcp/clickhouse_node_es.sh) that configures the machine with Clickhouse and ElasticSearch.
 - The startup script will fetch the latest version of the data from [Github](loaders/clickhouse) and call this [script](loaders/clickhouse/create_and_load_everything_from_scratch.sh) to add the data to ClickHouse and ElasticSearch.
+
+#### Notes and links
+
+- [`elasticsearch_loader`](https://pypi.org/project/elasticsearch-loader/) is a `pip` package used to import the Clickhouse data into ElasticSearch. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -65,3 +65,29 @@ You can use wget to download the release data. Below is an example of the comman
 ```bash
     wget --mirror ftp://ftp.ebi.ac.uk/pub/databases/opentargets/genetics/190504/
 ```
+
+## Clickhouse and Elastic Search
+
+| Date | Name | Version | 
+| --- | --- | --- | 
+| 11/6/20 | ElasticSearch | [7.7.1](https://www.elastic.co/guide/en/elasticsearch/reference/7.7/getting-started-install.html) |
+| 11/6/20 | ClickHouse | [20.1.4](https://clickhouse.tech/docs/en/) |
+ 
+
+
+Clickhouse is currently used by the Genetics Platform and API. A number of [scripts](gcp/clickhouse) are provided to 
+create and configure VM instances. 
+
+- __bake\_clickhouse\_*.sh__: Create a GCP compute engine _image_ 
+- __clickhouse\_node\_es.sh__: Initialisation script to install and configure Clickhouse and ElasticSearch  
+- __clickhouse\_node\_sumstats.sh__: Initialisation script to install and configure Clickhouse  
+- __create\_clickhouse\_node*.sh__: Create GCP _instance_  
+
+### Creating the persistence layer for the Genetics API
+
+- Create the machine with this [script](gcp/create_clickhouse_node_es.sh). It automatically calls a [startup script](gcp/clickhouse_node_es.sh) that configures the machine with Clickhouse and ElasticSearch.
+- The startup script will fetch the latest version of the data from [Github](loaders/clickhouse) and call this [script](loaders/clickhouse/create_and_load_everything_from_scratch.sh) to add the data to ClickHouse and ElasticSearch.
+
+
+
+ 

--- a/gcp/bake_clickhouse_image.sh
+++ b/gcp/bake_clickhouse_image.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+echo create a image from machine boot disk
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <machine-name-source> <image-name>"
+    echo "Example: $0 clickhouse-0230-dev clickhouse-0230"
+    exit 1
+fi
+
+ot_project=open-targets-genetics
+instance_name=$1
+image_name=$2
+
+
+gcloud --project=$ot_project \
+    compute instances stop $instance_name
+
+gcloud --project=$ot_project \
+    compute images create "${image_name}" \
+    --source-disk $instance_name \
+    --family ot-ch
+
+echo done it.

--- a/gcp/bake_clickhouse_image_sumstats.sh
+++ b/gcp/bake_clickhouse_image_sumstats.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+echo create a image from machine boot disk
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <machine-name-source> <image-name>"
+    echo "Example: $0 clickhouse-sumstats-190501-mk clickhouse-sumstats-190501"
+    exit 1
+fi
+
+ot_project=open-targets-genetics
+instance_name=$1
+image_name=$2
+
+
+gcloud --project=$ot_project \
+    compute instances stop $instance_name
+
+gcloud --project=$ot_project \
+    compute images create "${image_name}" \
+    --source-disk $instance_name \
+    --family ot-ch
+
+echo done it.

--- a/gcp/clickhouse_node_es.sh
+++ b/gcp/clickhouse_node_es.sh
@@ -18,7 +18,7 @@ fi
 ## Versions
 clickhouseVersion=20.4.5.36
 elastic_version=7.x
-backend_version=20.02.03
+backend_version=es7-test
 genetics_data="gs://genetics-portal-output/20022712"
 
 # Install dependencies
@@ -325,7 +325,7 @@ echo copying dictionaries from gcloud to clickhouse dictionaries folder
 gsutil cp gs://genetics-portal-data/lut/v2g_scoring_source_weights.190521.json \
     /etc/clickhouse-server/dictionaries/v2g_scoring_source_weights.json
 
-chown -R clickhouse:clickhouse dictionaries/
+chown -R clickhouse:clickhouse /etc/clickhouse-server/dictionaries/
 
 systemctl enable clickhouse-server
 systemctl start clickhouse-server

--- a/gcp/clickhouse_node_es.sh
+++ b/gcp/clickhouse_node_es.sh
@@ -7,7 +7,7 @@ if [ -f "$OT_RCFILE" ]; then
     exit 0
 fi
 
-clickhouseVersion=20.4.1.14
+clickhouseVersion=20.4.5.36
 elastic_version=7.7.1
 
 apt-get update && DEBIAN_FRONTEND=noninteractive \
@@ -26,15 +26,15 @@ apt-get update && DEBIAN_FRONTEND=noninteractive \
 pip install elasticsearch-loader
 
 
-elastic_deb=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elastic_version}.deb
+elastic_deb=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elastic_version}-amd64.deb
 kibana_deb=https://artifacts.elastic.co/downloads/kibana/kibana-${elastic_version}-amd64.deb
 
 cluster_id=$(uuidgen -r)
 
 (cd /tmp; \
  wget --no-check-certificate $elastic_deb; \
- dpkg -i elasticsearch-${elastic_version}.deb; \
- rm -f elasticsearch-${elastic_version}.deb)
+ dpkg -i elasticsearch-${elastic_version}-amd64.deb; \
+ rm -f elasticsearch-${elastic_version}-amd64.deb)
 
 cat <<EOF > /etc/elasticsearch/elasticsearch.yml
 cluster.name: ${cluster_id}

--- a/gcp/clickhouse_node_es.sh
+++ b/gcp/clickhouse_node_es.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+
+OT_RCFILE=/etc/opentargets.rc
+
+if [ -f "$OT_RCFILE" ]; then
+    echo "$OT_RCFILE exist so machine is already configured"
+    exit 0
+fi
+
+clickhouseVersion=20.4.1.14
+elastic_version=7.7.1
+
+apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    dist-upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    install default-jdk openjdk-11-jdk-headless bzip2 unzip zip wget net-tools wget uuid-runtime python-pip python-dev libyaml-dev httpie jq gawk tmux git build-essential less silversearcher-ag dirmngr psmisc
+
+pip install elasticsearch-loader
+
+
+elastic_deb=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elastic_version}.deb
+kibana_deb=https://artifacts.elastic.co/downloads/kibana/kibana-${elastic_version}-amd64.deb
+
+cluster_id=$(uuidgen -r)
+
+(cd /tmp; \
+ wget --no-check-certificate $elastic_deb; \
+ dpkg -i elasticsearch-${elastic_version}.deb; \
+ rm -f elasticsearch-${elastic_version}.deb)
+
+cat <<EOF > /etc/elasticsearch/elasticsearch.yml
+cluster.name: ${cluster_id}
+network.host: 0.0.0.0
+http.port: 9200
+bootstrap.memory_lock: true
+
+EOF
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/master/jvm-options.html
+cat <<EOF > /etc/elasticsearch/jvm.options.d/conf
+-Xms16g
+-Xmx16g
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+-XX:+DisableExplicitGC
+-XX:+AlwaysPreTouch
+-server
+-Xss1m
+-Djava.awt.headless=true
+-Dfile.encoding=UTF-8
+-Djna.nosys=true
+-Djdk.io.permissionsUseCanonicalPath=true
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+-XX:+HeapDumpOnOutOfMemoryError
+
+EOF
+
+cat <<EOF > /etc/security/limits.conf
+* soft nofile 65536
+* hard nofile 65536
+* soft memlock unlimited
+* hard memlock unlimited
+
+EOF
+
+cat <<EOF > /etc/sysctl.conf
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.tcp_syncookies = 1
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+net.ipv4.ip_forward = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+kernel.randomize_va_space = 1
+fs.file-max = 65535
+kernel.pid_max = 65536
+net.ipv4.ip_local_port_range = 2000 65000
+net.ipv4.tcp_window_scaling = 1
+net.ipv4.tcp_max_syn_backlog = 3240000
+net.ipv4.tcp_fin_timeout = 15
+net.core.somaxconn = 65535
+net.ipv4.tcp_max_tw_buckets = 1440000
+net.core.rmem_default = 8388608
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 65536 16777216
+net.ipv4.tcp_congestion_control = cubic
+vm.swappiness = 1
+net.ipv4.tcp_tw_reuse = 1
+
+EOF
+
+# set all sysctl configurations
+sysctl -p
+
+# echo disable swap noop scheduler
+# swapoff -a
+# echo 'never' | tee /sys/kernel/mm/transparent_hugepage/enabled
+echo 'noop' | tee /sys/block/sda/queue/scheduler
+echo "block/sda/queue/scheduler = noop" >> /etc/sysfs.conf
+# echo "kernel/mm/transparent_hugepage/enabled = never" >> /etc/sysfs.conf
+
+sed -i 's/\#LimitMEMLOCK=infinity/LimitMEMLOCK=infinity/g' /usr/lib/systemd/system/elasticsearch.service
+sed -i '46iLimitMEMLOCK=infinity' /usr/lib/systemd/system/elasticsearch.service
+
+systemctl daemon-reload
+echo install elasticsearch plugins gcs and gce
+
+echo start elasticsearch
+systemctl enable elasticsearch
+
+# /etc/init.d/elasticsearch start
+systemctl start elasticsearch
+
+echo install kibana
+
+(cd /tmp; \
+ wget --no-check-certificate $kibana_deb; \
+ dpkg -i kibana-${elastic_version}-amd64.deb; \
+ rm -f kibana-${elastic_version}-amd64.deb)
+
+cat <<EOF > /etc/kibana/kibana.yml
+server.port: 5601
+server.host: "localhost"
+elasticsearch.url: "http://127.0.0.1:9200"
+
+EOF
+
+echo start kibana
+
+systemctl enable kibana
+
+sleep 3 && systemctl start kibana
+
+echo install clickhouse
+echo "deb http://repo.yandex.ru/clickhouse/deb/stable/ main/" > /etc/apt/sources.list.d/clickhouse.list
+
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4
+apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    dist-upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    install clickhouse-client=$clickhouseVersion clickhouse-server=$clickhouseVersion
+
+service clickhouse-server stop
+/etc/init.d/clickhouse-server stop
+killall clickhouse-server && sleep 5 
+
+cat <<EOF > /etc/clickhouse-server/config.xml
+<?xml version="1.0"?>
+<yandex>
+    <logger>
+        <level>warning</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <size>1000M</size>
+        <count>7</count>
+    </logger>
+    <display_name>ot-genetics</display_name>
+    <http_port>8123</http_port>
+    <tcp_port>9000</tcp_port>
+    <interserver_http_port>9009</interserver_http_port>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>0</listen_try>
+    <listen_reuse_port>1</listen_reuse_port>
+    <listen_backlog>256</listen_backlog>
+    <max_connections>2048</max_connections>
+    <keep_alive_timeout>60</keep_alive_timeout>
+    <max_concurrent_queries>256</max_concurrent_queries>
+    <max_open_files>262144</max_open_files>
+    <uncompressed_cache_size>17179869184</uncompressed_cache_size>
+    <mark_cache_size>17179869184</mark_cache_size>
+    <!-- Path to data directory, with trailing slash. -->
+    <path>/var/lib/clickhouse/</path>
+    <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
+    <user_files_path>/var/lib/clickhouse/user_files/</user_files_path>
+    <users_config>users.xml</users_config>
+    <default_profile>default</default_profile>
+    <!-- <system_profile>default</system_profile> -->
+    <default_database>default</default_database>
+    <umask>022</umask>
+    <zookeeper incl="zookeeper-servers" optional="true" />
+    <macros incl="macros" optional="true" />
+    <dictionaries_config>*_dictionary.xml</dictionaries_config>
+    <builtin_dictionaries_reload_interval>3600</builtin_dictionaries_reload_interval>
+    <max_session_timeout>3600</max_session_timeout>
+    <default_session_timeout>60</default_session_timeout>
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+    </distributed_ddl>
+    <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
+</yandex>
+EOF
+
+cat <<EOF > /etc/clickhouse-server/users.xml
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+            <max_memory_usage>100000000000</max_memory_usage>
+		    <max_bytes_before_external_sort>80000000000</max_bytes_before_external_sort>
+		    <max_bytes_before_external_group_by>80000000000</max_bytes_before_external_group_by>
+            <use_uncompressed_cache>1</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+        </default>
+        <readonly>
+            <max_memory_usage>100000000000</max_memory_usage>
+		    <max_bytes_before_external_sort>80000000000</max_bytes_before_external_sort>
+		    <max_bytes_before_external_group_by>80000000000</max_bytes_before_external_group_by>
+            <use_uncompressed_cache>1</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+            <readonly>128</readonly>
+        </readonly>
+    </profiles>
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+                <ip>0.0.0.0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+        <readonly>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+                <ip>0.0.0.0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </readonly>
+    </users>
+    <quotas>
+        <default>
+            <interval>
+                <duration>3600</duration>
+                <queries>0</queries>
+                <errors>0</errors>
+                <result_rows>0</result_rows>
+                <read_rows>0</read_rows>
+                <execution_time>0</execution_time>
+            </interval>
+        </default>
+    </quotas>
+</yandex>
+EOF
+
+cat <<EOF > /etc/clickhouse-server/v2g_weights_dictionary.xml
+<dictionaries>
+	<dictionary>
+        <name>v2gw</name>
+        <source>
+		    <file>
+	            <path>/etc/clickhouse-server/dictionaries/v2g_scoring_source_weights.json</path>
+	            <format>JSONEachRow</format>
+		    </file>
+        </source>
+        <layout>
+            <complex_key_hashed />
+        </layout>
+        <lifetime>600</lifetime>
+        <structure>
+            <key>
+                <attribute>
+                    <name>source_id</name>
+                    <type>String</type>
+                </attribute>
+            </key>
+            <attribute>
+                <name>weight</name>
+                <type>Float64</type>
+                <null_value>0.0</null_value>
+            </attribute>
+        </structure>
+	</dictionary>
+</dictionaries>
+EOF
+
+mkdir /etc/clickhouse-server/dictionaries
+echo copying dictionaries from gcloud to clickhouse dictionaries folder 
+gsutil cp gs://genetics-portal-data/lut/v2g_scoring_source_weights.190521.json \
+    /etc/clickhouse-server/dictionaries/v2g_scoring_source_weights.json
+
+chown -R clickhouse:clickhouse dictionaries/
+
+systemctl enable clickhouse-server
+systemctl start clickhouse-server
+
+echo "starting clickhouse... done."
+
+cat <<EOF > /etc/tmux.conf
+set -g status "on"
+unbind C-b
+set-option -g prefix M-x
+bind-key M-x send-prefix
+bind | split-window -h
+bind - split-window -v
+bind x killp
+unbind '"'
+unbind %
+bind r source-file ~/.tmux.conf
+bind -n M-S-Left select-window -p
+bind -n M-S-Right select-window -n
+bind -n M-Left select-pane -L
+bind -n M-Right select-pane -R
+bind -n M-Up select-pane -U
+bind -n M-Down select-pane -D
+set-option -g allow-rename off
+set -g mouse on
+set -g pane-border-fg black
+set -g pane-active-border-fg brightred
+set -g status-justify left
+set -g status-interval 2
+setw -g window-status-format " #F#I:#W#F "
+setw -g window-status-current-format " #F#I:#W#F "
+# setw -g window-status-format "#[fg=magenta]#[bg=black] #I #[bg=cyan]#[fg=colour8] #W "
+# setw -g window-status-current-format "#[bg=brightmagenta]#[fg=colour8] #I #[fg=colour8]#[bg=colour14] #W "
+setw -g window-status-current-attr dim
+setw -g window-status-attr reverse
+
+set -g status-left ''
+
+set-option -g visual-activity off
+set-option -g visual-bell off
+set-option -g visual-silence off
+set-window-option -g monitor-activity off
+set-option -g bell-action none
+
+setw -g mode-attr bold
+set -g status-position bottom
+set -g status-attr dim
+set -g status-left ''
+# set -g status-right '#[fg=colour233,bg=colour245,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
+set -g status-right-length 50
+set -g status-left-length 20
+
+setw -g window-status-current-attr bold
+# setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#W#[fg=colour50]#F '
+
+setw -g window-status-attr none
+# setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#W#[fg=colour244]#F '
+
+setw -g window-status-bell-attr bold
+setw -g window-status-bell-fg colour255
+setw -g window-status-bell-bg colour1
+
+set -g message-attr bold
+set -g default-terminal "screen-256color"  # Setting the correct term
+set -g status-bg default # transparent
+set -g status-fg magenta
+set -g status-attr default
+setw -g window-status-fg blue
+setw -g window-status-bg default
+setw -g window-status-attr dim
+setw -g window-status-current-fg brightred
+setw -g window-status-current-bg default
+setw -g window-status-current-attr bright
+setw -g window-status-bell-bg red
+setw -g window-status-bell-fg white
+setw -g window-status-bell-attr bright
+setw -g window-status-activity-bg blue
+setw -g window-status-activity-fg white
+setw -g window-status-activity-attr bright
+set -g pane-border-fg white
+set -g pane-border-bg default
+set -g pane-active-border-fg brightblack
+set -g pane-active-border-bg default
+set -g message-fg default
+set -g message-bg default
+set -g message-attr bright
+
+EOF
+
+echo "do not forget to create the tables and load the data in"
+
+backend_version=20.02.03
+wget "https://github.com/opentargets/genetics-backend/archive/${backend_version}.zip"
+unzip "${backend_version}.zip"
+cd "genetics-backend-${backend_version}/loaders/clickhouse"
+bash create_and_load_everything_from_scratch.sh "gs://genetics-portal-output/20022712"
+
+echo touching $OT_RCFILE
+echo "backend_version=${backend_version}" > $OT_RCFILE
+date >> $OT_RCFILE

--- a/gcp/clickhouse_node_sumstats.sh
+++ b/gcp/clickhouse_node_sumstats.sh
@@ -1,0 +1,332 @@
+#!/bin/bash
+
+OT_RCFILE=/etc/opentargets_sumstats.rc
+
+if [ -f "$OT_RCFILE" ]; then
+    echo "$OT_RCFILE exist so machine is already configured"
+    exit 0
+fi
+
+apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    dist-upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    -t stretch-backports install openjdk-8-jdk-headless net-tools wget uuid-runtime python-pip python-dev libyaml-dev httpie jq gawk zip unzip tmux git build-essential less silversearcher-ag dirmngr psmisc
+
+# instance_name=$(http --ignore-stdin --check-status 'http://metadata.google.internal/computeMetadata/v1/instance/name'  "Metadata-Flavor:Google" -p b --pretty none)
+cluster_id=$(uuidgen -r)
+# cluster_id=$instance_name
+
+cat <<EOF > /etc/security/limits.conf
+* soft nofile 65536
+* hard nofile 65536
+* soft memlock unlimited
+* hard memlock unlimited
+
+EOF
+
+cat <<EOF > /etc/sysctl.conf
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.tcp_syncookies = 1
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+net.ipv4.ip_forward = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+kernel.randomize_va_space = 1
+fs.file-max = 65535
+kernel.pid_max = 65536
+net.ipv4.ip_local_port_range = 2000 65000
+net.ipv4.tcp_window_scaling = 1
+net.ipv4.tcp_max_syn_backlog = 3240000
+net.ipv4.tcp_fin_timeout = 15
+net.core.somaxconn = 65535
+net.ipv4.tcp_max_tw_buckets = 1440000
+net.core.rmem_default = 8388608
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 65536 16777216
+net.ipv4.tcp_congestion_control = cubic
+vm.swappiness = 1
+net.ipv4.tcp_tw_reuse = 1
+
+EOF
+
+# set all sysctl configurations
+sysctl -p
+
+# echo disable swap noop scheduler
+# swapoff -a
+# echo 'never' | tee /sys/kernel/mm/transparent_hugepage/enabled
+echo 'noop' | tee /sys/block/sda/queue/scheduler
+echo "block/sda/queue/scheduler = noop" >> /etc/sysfs.conf
+# echo "kernel/mm/transparent_hugepage/enabled = never" >> /etc/sysfs.conf
+
+sed -i 's/\#LimitMEMLOCK=infinity/LimitMEMLOCK=infinity/g' /usr/lib/systemd/system/elasticsearch.service
+sed -i '46iLimitMEMLOCK=infinity' /usr/lib/systemd/system/elasticsearch.service
+
+systemctl daemon-reload
+
+echo install clickhouse
+echo "deb http://repo.yandex.ru/clickhouse/deb/stable/ main/" > /etc/apt/sources.list.d/clickhouse.list
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv E0C56BD4
+apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    dist-upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get \
+    -o Dpkg::Options::="--force-confnew" \
+    --force-yes \
+    -fuy \
+    install clickhouse-client clickhouse-server
+
+service clickhouse-server stop
+/etc/init.d/clickhouse-server stop
+killall clickhouse-server && sleep 5 
+
+cat <<EOF > /etc/clickhouse-server/config.xml
+<?xml version="1.0"?>
+<yandex>
+    <logger>
+        <level>warning</level>
+        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+        <size>1000M</size>
+        <count>7</count>
+    </logger>
+    <display_name>ot-genetics</display_name>
+    <http_port>8123</http_port>
+    <tcp_port>9000</tcp_port>
+    <interserver_http_port>9009</interserver_http_port>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>0</listen_try>
+    <listen_reuse_port>1</listen_reuse_port>
+    <listen_backlog>256</listen_backlog>
+    <max_connections>2048</max_connections>
+    <keep_alive_timeout>5</keep_alive_timeout>
+    <max_concurrent_queries>256</max_concurrent_queries>
+    <max_open_files>262144</max_open_files>
+    <uncompressed_cache_size>17179869184</uncompressed_cache_size>
+    <mark_cache_size>17179869184</mark_cache_size>
+    <!-- Path to data directory, with trailing slash. -->
+    <path>/var/lib/clickhouse/</path>
+    <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
+    <user_files_path>/var/lib/clickhouse/user_files/</user_files_path>
+    <users_config>users.xml</users_config>
+    <default_profile>default</default_profile>
+    <!-- <system_profile>default</system_profile> -->
+    <default_database>default</default_database>
+    <umask>022</umask>
+    <zookeeper incl="zookeeper-servers" optional="true" />
+    <macros incl="macros" optional="true" />
+    <dictionaries_config>*_dictionary.xml</dictionaries_config>
+    <builtin_dictionaries_reload_interval>3600</builtin_dictionaries_reload_interval>
+    <max_session_timeout>3600</max_session_timeout>
+    <default_session_timeout>60</default_session_timeout>
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+    </distributed_ddl>
+    <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
+</yandex>
+EOF
+
+cat <<EOF > /etc/clickhouse-server/users.xml
+<?xml version="1.0"?>
+<yandex>
+    <profiles>
+        <default>
+            <max_memory_usage>100000000000</max_memory_usage>
+		    <max_bytes_before_external_sort>80000000000</max_bytes_before_external_sort>
+		    <max_bytes_before_external_group_by>80000000000</max_bytes_before_external_group_by>
+            <use_uncompressed_cache>1</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+        </default>
+        <readonly>
+            <max_memory_usage>100000000000</max_memory_usage>
+		    <max_bytes_before_external_sort>80000000000</max_bytes_before_external_sort>
+		    <max_bytes_before_external_group_by>80000000000</max_bytes_before_external_group_by>
+            <use_uncompressed_cache>1</use_uncompressed_cache>
+            <load_balancing>random</load_balancing>
+            <readonly>128</readonly>
+        </readonly>
+    </profiles>
+    <users>
+        <default>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+                <ip>0.0.0.0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+        <readonly>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+                <ip>0.0.0.0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </readonly>
+    </users>
+    <quotas>
+        <default>
+            <interval>
+                <duration>3600</duration>
+                <queries>0</queries>
+                <errors>0</errors>
+                <result_rows>0</result_rows>
+                <read_rows>0</read_rows>
+                <execution_time>0</execution_time>
+            </interval>
+        </default>
+    </quotas>
+</yandex>
+EOF
+
+systemctl enable clickhouse-server
+systemctl start clickhouse-server
+
+echo "starting clickhouse... done."
+
+echo install stackdriver
+
+(cd /root && \
+    curl -O https://repo.stackdriver.com/stack-install.sh && \
+    bash stack-install.sh --write-gcm)
+
+(cd /root && \
+    curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh && \
+    sudo bash install-logging-agent.sh)
+
+service stackdriver-agent restart
+
+cat <<EOF > /etc/google-fluentd/config.d/clickhouse.conf
+<source>
+  @type tail
+  format none
+  path /var/log/clickhouse-server/clickhouse-server.*.log
+  pos_file /var/lib/google-fluentd/pos/elasticsearch.pos
+  read_from_head true
+  tag elasticsearch
+</source>
+EOF
+
+
+cat <<EOF > /etc/tmux.conf
+set -g status "on"
+unbind C-b
+set-option -g prefix M-x
+bind-key M-x send-prefix
+bind | split-window -h
+bind - split-window -v
+bind x killp
+unbind '"'
+unbind %
+bind r source-file ~/.tmux.conf
+bind -n M-S-Left select-window -p
+bind -n M-S-Right select-window -n
+bind -n M-Left select-pane -L
+bind -n M-Right select-pane -R
+bind -n M-Up select-pane -U
+bind -n M-Down select-pane -D
+set-option -g allow-rename off
+set -g mouse on
+set -g pane-border-fg black
+set -g pane-active-border-fg brightred
+set -g status-justify left
+set -g status-interval 2
+setw -g window-status-format " #F#I:#W#F "
+setw -g window-status-current-format " #F#I:#W#F "
+# setw -g window-status-format "#[fg=magenta]#[bg=black] #I #[bg=cyan]#[fg=colour8] #W "
+# setw -g window-status-current-format "#[bg=brightmagenta]#[fg=colour8] #I #[fg=colour8]#[bg=colour14] #W "
+setw -g window-status-current-attr dim
+setw -g window-status-attr reverse
+
+set -g status-left ''
+
+set-option -g visual-activity off
+set-option -g visual-bell off
+set-option -g visual-silence off
+set-window-option -g monitor-activity off
+set-option -g bell-action none
+
+setw -g mode-attr bold
+set -g status-position bottom
+set -g status-attr dim
+set -g status-left ''
+# set -g status-right '#[fg=colour233,bg=colour245,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
+set -g status-right-length 50
+set -g status-left-length 20
+
+setw -g window-status-current-attr bold
+# setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#W#[fg=colour50]#F '
+
+setw -g window-status-attr none
+# setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#W#[fg=colour244]#F '
+
+setw -g window-status-bell-attr bold
+setw -g window-status-bell-fg colour255
+setw -g window-status-bell-bg colour1
+
+set -g message-attr bold
+set -g default-terminal "screen-256color"  # Setting the correct term
+set -g status-bg default # transparent
+set -g status-fg magenta
+set -g status-attr default
+setw -g window-status-fg blue
+setw -g window-status-bg default
+setw -g window-status-attr dim
+setw -g window-status-current-fg brightred
+setw -g window-status-current-bg default
+setw -g window-status-current-attr bright
+setw -g window-status-bell-bg red
+setw -g window-status-bell-fg white
+setw -g window-status-bell-attr bright
+setw -g window-status-activity-bg blue
+setw -g window-status-activity-fg white
+setw -g window-status-activity-attr bright
+set -g pane-border-fg white
+set -g pane-border-bg default
+set -g pane-active-border-fg brightblack
+set -g pane-active-border-bg default
+set -g message-fg default
+set -g message-bg default
+set -g message-attr bright
+
+EOF
+
+service google-fluentd restart
+
+echo "do not forget to create the tables and load the data in"
+
+backend_version=19.05.21
+wget "https://github.com/opentargets/genetics-backend/archive/${backend_version}.zip"
+unzip "${backend_version}.zip"
+cd "genetics-backend-${backend_version}/loaders/clickhouse"
+bash create_and_load_everything_from_scratch_summary_stats.sh
+
+echo touching $OT_RCFILE
+echo "backend_version=${backend_version}" > $OT_RCFILE
+date >> $OT_RCFILE

--- a/gcp/create_clickhouse_node_es.sh
+++ b/gcp/create_clickhouse_node_es.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+ot_project=open-targets-genetics
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <tag-name>"
+    exit 1
+fi
+
+gcloud compute instances create clickhouse-$1  \
+       --image-project debian-cloud \
+       --image-family debian-10 \
+       --machine-type n1-highmem-16 \
+       --zone europe-west1-d \
+       --metadata-from-file startup-script=clickhouse_node_es.sh \
+       --boot-disk-size "500" \
+       --boot-disk-type "pd-ssd" --boot-disk-device-name "clickhouse-ssd-$1" \
+       --project $ot_project \
+       --scopes default,storage-rw
+
+# --metadata es_server=http://10.132.0.3:9200,es_prefix=mkes5.2
+
+# --boot-disk-device-name "ot-es550" \

--- a/gcp/create_clickhouse_node_es.sh
+++ b/gcp/create_clickhouse_node_es.sh
@@ -18,6 +18,3 @@ gcloud compute instances create clickhouse-$1  \
        --project $ot_project \
        --scopes default,storage-rw
 
-# --metadata es_server=http://10.132.0.3:9200,es_prefix=mkes5.2
-
-# --boot-disk-device-name "ot-es550" \

--- a/gcp/create_clickhouse_node_sumstats.sh
+++ b/gcp/create_clickhouse_node_sumstats.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+ot_project=open-targets-genetics
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <tag-name>"
+    exit 1
+fi
+
+gcloud compute instances create clickhouse-sumstats-$1  \
+       --image-project debian-cloud \
+       --image-family debian-9 \
+       --machine-type n1-highmem-8 \
+       --zone europe-west1-d \
+       --metadata-from-file startup-script=clickhouse_node_sumstats.sh \
+       --boot-disk-size "500" \
+       --boot-disk-type "pd-ssd" --boot-disk-device-name "clickhouse-sumstats-ssd-$1" \
+       --project $ot_project \
+       --scopes default,storage-rw
+

--- a/loaders/clickhouse/create_and_load_everything_from_scratch.sh
+++ b/loaders/clickhouse/create_and_load_everything_from_scratch.sh
@@ -4,63 +4,63 @@
 
 export ES_HOST="${ES_HOST:-localhost}"
 export CLICKHOUSE_HOST="${CLICKHOUSE_HOST:-localhost}"
-export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 if [ $# -ne 1 ]; then
-    echo "Recreates ot database and loads data."
-    echo "Example: $0 gs://genetics-portal-output/190504"
-    exit 1
+  echo "Recreates ot database and loads data."
+  echo "Example: $0 gs://genetics-portal-output/190504"
+  exit 1
 fi
 base_path="${1}"
 
-load_foreach_json(){
-    # you need two parameters, the path_prefix to make the wildcard and
-    # the table_name name to load into
-    local path_prefix=$1
-    local table_name=$2
-    echo loading $path_prefix glob files into this table $table_name
-    gs_files=$("${SCRIPT_DIR}/run.sh" ls "${path_prefix}"/part-*)
-    for file in $gs_files; do
-            echo $file
-            "${SCRIPT_DIR}/run.sh" cat "${file}" | \
-             clickhouse-client -h "${CLICKHOUSE_HOST}" \
-                 --query="insert into ${table_name} format JSONEachRow "
-    done
-    echo "done loading $path_prefix glob files into this table $table_name"
+load_foreach_json() {
+  # you need two parameters, the path_prefix to make the wildcard and
+  # the table_name name to load into
+  local path_prefix=$1
+  local table_name=$2
+  echo loading $path_prefix glob files into this table $table_name
+  gs_files=$("${SCRIPT_DIR}/run.sh" ls "${path_prefix}"/part-*)
+  for file in $gs_files; do
+    echo $file
+    "${SCRIPT_DIR}/run.sh" cat "${file}" |
+      clickhouse-client -h "${CLICKHOUSE_HOST}" \
+        --query="insert into ${table_name} format JSONEachRow "
+  done
+  echo "done loading $path_prefix glob files into this table $table_name"
 }
 
-load_foreach_json_gz(){
-    # you need two parameters, the path_prefix to make the wildcard and
-    # the table_name name to load into
-    # this function is a temporal fix for a jsonlines dataset where files
-    # come compressed
-    local path_prefix=$1
-    local table_name=$2
-    echo loading $path_prefix glob files into this table $table_name
-    gs_files=$("${SCRIPT_DIR}/run.sh" ls "${path_prefix}"/part-*)
-    for file in $gs_files; do
-            echo $file
-            "${SCRIPT_DIR}/run.sh" cat "${file}" | gunzip | \
-             clickhouse-client -h "${CLICKHOUSE_HOST}" \
-                 --query="insert into ${table_name} format JSONEachRow "
-    done
-    echo "done loading $path_prefix glob files into this table $table_name"
+load_foreach_json_gz() {
+  # you need two parameters, the path_prefix to make the wildcard and
+  # the table_name name to load into
+  # this function is a temporal fix for a jsonlines dataset where files
+  # come compressed
+  local path_prefix=$1
+  local table_name=$2
+  echo loading $path_prefix glob files into this table $table_name
+  gs_files=$("${SCRIPT_DIR}/run.sh" ls "${path_prefix}"/part-*)
+  for file in $gs_files; do
+    echo $file
+    "${SCRIPT_DIR}/run.sh" cat "${file}" | gunzip |
+      clickhouse-client -h "${CLICKHOUSE_HOST}" \
+        --query="insert into ${table_name} format JSONEachRow "
+  done
+  echo "done loading $path_prefix glob files into this table $table_name"
 }
 
-load_foreach_parquet(){
-    # you need two parameters, the path_prefix to make the wildcard and
-    # the table_name name to load into
-    local path_prefix=$1
-    local table_name=$2
-    echo loading $path_prefix glob files into this table $table_name
-    gs_files=$("${SCRIPT_DIR}/run.sh" ls "${path_prefix}"/*.parquet)
-    for file in $gs_files; do
-            echo $file
-            "${SCRIPT_DIR}/run.sh" cat "${file}" | \
-             clickhouse-client -h "${CLICKHOUSE_HOST}" \
-                 --query="insert into ${table_name} format Parquet "
-    done
-    echo "done loading $path_prefix glob files into this table $table_name"
+load_foreach_parquet() {
+  # you need two parameters, the path_prefix to make the wildcard and
+  # the table_name name to load into
+  local path_prefix=$1
+  local table_name=$2
+  echo loading $path_prefix glob files into this table $table_name
+  gs_files=$("${SCRIPT_DIR}/run.sh" ls "${path_prefix}"/*.parquet)
+  for file in $gs_files; do
+    echo $file
+    "${SCRIPT_DIR}/run.sh" cat "${file}" |
+      clickhouse-client -h "${CLICKHOUSE_HOST}" \
+        --query="insert into ${table_name} format Parquet "
+  done
+  echo "done loading $path_prefix glob files into this table $table_name"
 }
 
 # CURRENTLY, IN ORDER TO BUILD SOME TABLES WE NEED A HIGHMEM MACHINE
@@ -69,112 +69,103 @@ load_foreach_parquet(){
 clickhouse-client -h "${CLICKHOUSE_HOST}" --query="drop database if exists ot;"
 
 echo create genes table
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/genes.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/genes.sql"
 load_foreach_json "${base_path}/lut/genes-index" "ot.genes"
 
 echo create studies tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/studies_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/studies_log.sql"
 load_foreach_json "${base_path}/lut/study-index" "ot.studies_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/studies.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/studies.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.studies_log;"
 
 echo create studies overlap tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/studies_overlap_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/studies_overlap_log.sql"
 load_foreach_json "${base_path}/lut/overlap-index" "ot.studies_overlap_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/studies_overlap.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/studies_overlap.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.studies_overlap_log;"
 
 echo create dictionaries tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/dictionaries.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/dictionaries.sql"
 
 echo create variants tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/variants_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/variants_log.sql"
 load_foreach_json "${base_path}/lut/variant-index" "ot.variants_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/variants.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/variants.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.variants_log;"
 
 echo create d2v2g tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/d2v2g_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/d2v2g_log.sql"
 load_foreach_json "${base_path}/d2v2g" "ot.d2v2g_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/d2v2g.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/d2v2g.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.d2v2g_log;"
 
 echo create v2d tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_log.sql"
 load_foreach_json "${base_path}/v2d" "ot.v2d_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.v2d_log;"
 
 echo create v2g tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2g_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2g_log.sql"
 load_foreach_json "${base_path}/v2g" "ot.v2g_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2g.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2g.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.v2g_log;"
 
 echo create v2g structure
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2g_structure.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2g_structure.sql"
 
 #echo compute v2g_scored table
 #clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2g_scored.sql"
 
 echo compute d2v2g_scored table
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/d2v2g_scored.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/d2v2g_scored.sql"
 
 # echo compute locus 2 gene table
 # clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/d2v2g_scored_l2g.sql"
 
 echo load coloc data
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_coloc_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_coloc_log.sql"
 load_foreach_json "${base_path}/v2d_coloc" "ot.v2d_coloc_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_coloc.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_coloc.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.v2d_coloc_log;"
 
 echo load credible set
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_credibleset_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_credibleset_log.sql"
 load_foreach_json_gz "${base_path}/v2d_credset" "ot.v2d_credset_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_credibleset.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_credibleset.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.v2d_credset_log;"
 
 echo generate sumstats gwas tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_sa_gwas_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_sa_gwas_log.sql"
 load_foreach_parquet "${base_path}/sa/gwas" "ot.v2d_sa_gwas_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_sa_gwas.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_sa_gwas.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table if exists ot.v2d_sa_gwas_log;"
 
 echo generate sumstats molecular trait tables
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_sa_molecular_traits_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_sa_molecular_traits_log.sql"
 load_foreach_parquet "${base_path}/sa/molecular_trait" "ot.v2d_sa_molecular_trait_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/v2d_sa_molecular_traits.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2d_sa_molecular_traits.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table if exists ot.v2d_sa_molecular_trait_log;"
 
 echo load locus 2 gene
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/l2g_log.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/l2g_log.sql"
 load_foreach_parquet "${base_path}/l2g" "ot.l2g_log"
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/l2g.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/l2g.sql"
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n -q "drop table ot.l2g_log;"
 
 echo building manhattan table
-clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n < "${SCRIPT_DIR}/manhattan.sql"
+clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/manhattan.sql"
 
-# elasticsearch process
 echo load elasticsearch studies data
-curl -XDELETE "${ES_HOST}:9200/studies"
-# TODO this is a temporal workaround as elasticsearch does not like explicit null values for fields and the studies are not yet properly filetered
-# "${SCRIPT_DIR}/run.sh" cat "${base_path}"/lut/study-index/part-* | elasticsearch_loader --es-host "http://${ES_HOST}:9200" --index-settings-file "${SCRIPT_DIR}/index_settings_studies.json" --bulk-size 10000 --index studies --type study json --json-lines -
-clickhouse-client -h "${CLICKHOUSE_HOST}" --query="select * from ot.studies format JSONEachRow "| \
-    jq -r 'del(.[] | nulls)|@json' | \
-    elasticsearch_loader --es-host "http://${ES_HOST}:9200" --index-settings-file "${SCRIPT_DIR}/index_settings_studies.json" --bulk-size 10000 --index studies --type study json --json-lines -
+clickhouse-client -h "${CLICKHOUSE_HOST}" --query="select * from ot.studies format JSONEachRow " |
+  jq -r 'del(.[] | nulls)|@json' |
+  elasticsearch_loader --es-host "http://${ES_HOST}:9200" --index-settings-file "${SCRIPT_DIR}/index_settings_studies.json" --bulk-size 10000 --index studies --delete json --json-lines -
 
 echo load elasticsearch genes data
-curl -XDELETE "${ES_HOST}:9200/genes"
-"${SCRIPT_DIR}/run.sh" cat "${base_path}"/lut/genes-index/part-* | elasticsearch_loader --es-host "http://${ES_HOST}:9200" --index-settings-file "${SCRIPT_DIR}/index_settings_genes.json" --bulk-size 10000 --index genes --type gene json --json-lines -
+"${SCRIPT_DIR}/run.sh" cat "${base_path}"/lut/genes-index/part-* | elasticsearch_loader --es-host "http://${ES_HOST}:9200" --index-settings-file "${SCRIPT_DIR}/index_settings_genes.json" --bulk-size 10000 --index genes --delete json --json-lines -
 
 echo load elasticsearch variants data
 for chr in "1" "2" "3" "4" "5" "6" "7" "8" "9" "10" "11" "12" "13" "14" "15" "16" "17" "18" "19" "20" "21" "22" "x" "y" "mt"; do
-	chrU=$(echo -n $chr | awk '{print toupper($0)}')
-	curl -XDELETE "${ES_HOST}:9200/variant_${chr}"
-	clickhouse-client -h "${CLICKHOUSE_HOST}" -q "select * from ot.variants prewhere chr_id = '${chrU}' format JSONEachRow" | elasticsearch_loader --es-host "http://${ES_HOST}:9200" --index-settings-file "${SCRIPT_DIR}/index_settings_variants.json" --bulk-size 10000 --index variant_$chr --type variant json --json-lines -
+  chrU=$(echo -n $chr | awk '{print toupper($0)}')
+  clickhouse-client -h "${CLICKHOUSE_HOST}" -q "select * from ot.variants prewhere chr_id = '${chrU}' format JSONEachRow" | elasticsearch_loader --es-host "http://${ES_HOST}:9200" --index-settings-file "${SCRIPT_DIR}/index_settings_variants.json" --bulk-size 10000 --index variant_$chr --delete json --json-lines -
 done
-
-
-

--- a/loaders/clickhouse/index_settings.json
+++ b/loaders/clickhouse/index_settings.json
@@ -1,139 +1,136 @@
 {
-        "settings": {
-                "index" : {
-                        "number_of_replicas" : 0
-                }
-        },
-
-        "mappings": {
-                "variant": {
-                        "properties": {
-                                "alt_allele": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                },
-                                "chr_id": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                },
-                                "gene_id": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                },
-                                "gene_id_distance": {
-                                        "type": "long"
-                                },
-                                "gene_id_prot_coding": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                },
-                                "gene_id_prot_coding_distance": {
-                                        "type": "long"
-                                },
-                                "gnomad_afr": {
-                                        "type": "float"
-                                },
-                                "gnomad_amr": {
-                                        "type": "float"
-                                },
-                                "gnomad_asj": {
-                                        "type": "float"
-                                },
-                               "gnomad_eas": {
-                                        "type": "float"
-                                },
-                                "gnomad_fin": {
-                                        "type": "float"
-                                },
-                                "gnomad_nfe": {
-                                        "type": "float"
-                                },
-                                "gnomad_nfe_est": {
-                                        "type": "float"
-                                },
-                                "gnomad_nfe_nwe": {
-                                        "type": "float"
-                                },
-                                "gnomad_nfe_onf": {
-                                        "type": "float"
-                                },
-                                "gnomad_nfe_seu": {
-                                        "type": "float"
-                                },
-                                "gnomad_oth": {
-                                        "type": "float"
-                                },
-                                "gnomad_seu": {
-                                        "type": "float"
-                                },
-                               "most_severe_consequence": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                },
-                                "phred": {
-                                        "type": "float"
-                                },
-                                "position": {
-                                        "type": "long"
-                                },
-                                "raw": {
-                                        "type": "float"
-                                },
-                                "ref_allele": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                },
-                               "rs_id": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                },
-                                "variant_id": {
-                                        "type": "text",
-                                        "fields": {
-                                                "keyword": {
-                                                        "type": "keyword",
-                                                        "ignore_above": 256
-                                                }
-                                        }
-                                }
-                        }
-                }
+  "settings": {
+    "index": {
+      "number_of_replicas": 0
+    }
+  },
+  "mappings": {
+    "properties": {
+      "alt_allele": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
         }
+      },
+      "chr_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "gene_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "gene_id_distance": {
+        "type": "long"
+      },
+      "gene_id_prot_coding": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "gene_id_prot_coding_distance": {
+        "type": "long"
+      },
+      "gnomad_afr": {
+        "type": "float"
+      },
+      "gnomad_amr": {
+        "type": "float"
+      },
+      "gnomad_asj": {
+        "type": "float"
+      },
+      "gnomad_eas": {
+        "type": "float"
+      },
+      "gnomad_fin": {
+        "type": "float"
+      },
+      "gnomad_nfe": {
+        "type": "float"
+      },
+      "gnomad_nfe_est": {
+        "type": "float"
+      },
+      "gnomad_nfe_nwe": {
+        "type": "float"
+      },
+      "gnomad_nfe_onf": {
+        "type": "float"
+      },
+      "gnomad_nfe_seu": {
+        "type": "float"
+      },
+      "gnomad_oth": {
+        "type": "float"
+      },
+      "gnomad_seu": {
+        "type": "float"
+      },
+      "most_severe_consequence": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "phred": {
+        "type": "float"
+      },
+      "position": {
+        "type": "long"
+      },
+      "raw": {
+        "type": "float"
+      },
+      "ref_allele": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "rs_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "variant_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      }
+    }
+  }
 }
 
 

--- a/loaders/clickhouse/index_settings_genes.json
+++ b/loaders/clickhouse/index_settings_genes.json
@@ -49,73 +49,71 @@
         }
       }
     }
-    },
-    "mappings": {
-      "gene": {
-        "properties": {
-          "biotype": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "chr": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "description": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "end": {
-            "type": "long"
-          },
-          "exons": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "fwdstrand": {
-            "type": "long"
-          },
-          "gene_id": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
-          },
-          "gene_name": {
-            "type": "text",
-            "analyzer": "autocomplete",
-            "search_analyzer": "autocomplete_search"
-          },
-          "start": {
-            "type": "long"
-          },
-          "tss": {
-            "type": "long"
+  },
+  "mappings": {
+    "properties": {
+      "biotype": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
         }
+      },
+      "chr": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "description": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "end": {
+        "type": "long"
+      },
+      "exons": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "fwdstrand": {
+        "type": "long"
+      },
+      "gene_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "gene_name": {
+        "type": "text",
+        "analyzer": "autocomplete",
+        "search_analyzer": "autocomplete_search"
+      },
+      "start": {
+        "type": "long"
+      },
+      "tss": {
+        "type": "long"
       }
     }
   }
+}

--- a/loaders/clickhouse/index_settings_studies.json
+++ b/loaders/clickhouse/index_settings_studies.json
@@ -5,7 +5,7 @@
       "analysis": {
         "filter": {
           "autocomplete_filter": {
-            "type":     "edge_ngram",
+            "type": "edge_ngram",
             "min_gram": 1,
             "max_gram": 20,
             "token_chars": [
@@ -30,7 +30,7 @@
         },
         "analyzer": {
           "autocomplete": {
-            "type":      "custom",
+            "type": "custom",
             "tokenizer": "whitespace",
             "filter": [
               "lowercase",
@@ -39,7 +39,7 @@
             ]
           },
           "autocomplete_search": {
-            "type":      "custom",
+            "type": "custom",
             "tokenizer": "whitespace",
             "filter": [
               "lowercase",
@@ -51,63 +51,60 @@
     }
   },
   "mappings": {
-    "study": {
-      "properties": {
-        "pub_author": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
-          },
-          "copy_to": "mixed_field"
-        },
-        "pub_date": {
-          "type": "date"
-        },
-        "pub_journal": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
-          },
-          "copy_to": "mixed_field"
-        },
-        "pub_title": {
-          "type": "text",
-          "analyzer": "standard",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            },
-            "completion": {
-              "type": "completion"
-            }
-          },
-          "copy_to": "mixed_field"
-        },
-        "trait_reported": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
-          },
-          "copy_to": "mixed_field"
-        },
-        "mixed_field": {
-          "type": "text",
-          "analyzer": "autocomplete",
-          "search_analyzer": "autocomplete_search"
+    "pub_author": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
         }
-      }
+      },
+      "copy_to": "mixed_field"
+    },
+    "pub_date": {
+      "type": "date"
+    },
+    "pub_journal": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      },
+      "copy_to": "mixed_field"
+    },
+    "pub_title": {
+      "type": "text",
+      "analyzer": "standard",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        },
+        "completion": {
+          "type": "completion"
+        }
+      },
+      "copy_to": "mixed_field"
+    },
+    "trait_reported": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      },
+      "copy_to": "mixed_field"
+    },
+    "mixed_field": {
+      "type": "text",
+      "analyzer": "autocomplete",
+      "search_analyzer": "autocomplete_search"
     }
   }
+}
 }
 
 

--- a/loaders/clickhouse/index_settings_studies.json
+++ b/loaders/clickhouse/index_settings_studies.json
@@ -51,61 +51,59 @@
     }
   },
   "mappings": {
-    "pub_author": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 256
-        }
-      },
-      "copy_to": "mixed_field"
-    },
-    "pub_date": {
-      "type": "date"
-    },
-    "pub_journal": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 256
-        }
-      },
-      "copy_to": "mixed_field"
-    },
-    "pub_title": {
-      "type": "text",
-      "analyzer": "standard",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 256
+    "properties": {
+      "pub_author": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
         },
-        "completion": {
-          "type": "completion"
-        }
+        "copy_to": "mixed_field"
       },
-      "copy_to": "mixed_field"
-    },
-    "trait_reported": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword",
-          "ignore_above": 256
-        }
+      "pub_date": {
+        "type": "date"
       },
-      "copy_to": "mixed_field"
-    },
-    "mixed_field": {
-      "type": "text",
-      "analyzer": "autocomplete",
-      "search_analyzer": "autocomplete_search"
+      "pub_journal": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        },
+        "copy_to": "mixed_field"
+      },
+      "pub_title": {
+        "type": "text",
+        "analyzer": "standard",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "completion": {
+            "type": "completion"
+          }
+        },
+        "copy_to": "mixed_field"
+      },
+      "trait_reported": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        },
+        "copy_to": "mixed_field"
+      },
+      "mixed_field": {
+        "type": "text",
+        "analyzer": "autocomplete",
+        "search_analyzer": "autocomplete_search"
+      }
     }
   }
 }
-}
-
-
-

--- a/loaders/clickhouse/index_settings_variants.json
+++ b/loaders/clickhouse/index_settings_variants.json
@@ -1,134 +1,131 @@
 {
   "settings": {
-    "index" : {
-      "number_of_replicas" : 0
+    "index": {
+      "number_of_replicas": 0
     }
   },
-
   "mappings": {
-    "variant": {
-      "properties": {
-        "alt_allele": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+    "properties": {
+      "alt_allele": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "chr_id": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+        }
+      },
+      "chr_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "gene_id": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+        }
+      },
+      "gene_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "gene_id_distance": {
-          "type": "long"
-        },
-        "gene_id_prot_coding": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+        }
+      },
+      "gene_id_distance": {
+        "type": "long"
+      },
+      "gene_id_prot_coding": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "gene_id_prot_coding_distance": {
-          "type": "long"
-        },
-        "gnomad_afr": {
-          "type": "float"
-        },
-        "gnomad_amr": {
-          "type": "float"
-        },
-        "gnomad_asj": {
-          "type": "float"
-        },
-        "gnomad_eas": {
-          "type": "float"
-        },
-        "gnomad_fin": {
-          "type": "float"
-        },
-        "gnomad_nfe": {
-          "type": "float"
-        },
-        "gnomad_nfe_est": {
-          "type": "float"
-        },
-        "gnomad_nfe_nwe": {
-          "type": "float"
-        },
-        "gnomad_nfe_onf": {
-          "type": "float"
-        },
-        "gnomad_nfe_seu": {
-          "type": "float"
-        },
-        "gnomad_oth": {
-          "type": "float"
-        },
-        "gnomad_seu": {
-          "type": "float"
-        },
-        "most_severe_consequence": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+        }
+      },
+      "gene_id_prot_coding_distance": {
+        "type": "long"
+      },
+      "gnomad_afr": {
+        "type": "float"
+      },
+      "gnomad_amr": {
+        "type": "float"
+      },
+      "gnomad_asj": {
+        "type": "float"
+      },
+      "gnomad_eas": {
+        "type": "float"
+      },
+      "gnomad_fin": {
+        "type": "float"
+      },
+      "gnomad_nfe": {
+        "type": "float"
+      },
+      "gnomad_nfe_est": {
+        "type": "float"
+      },
+      "gnomad_nfe_nwe": {
+        "type": "float"
+      },
+      "gnomad_nfe_onf": {
+        "type": "float"
+      },
+      "gnomad_nfe_seu": {
+        "type": "float"
+      },
+      "gnomad_oth": {
+        "type": "float"
+      },
+      "gnomad_seu": {
+        "type": "float"
+      },
+      "most_severe_consequence": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "phred": {
-          "type": "float"
-        },
-        "position": {
-          "type": "long"
-        },
-        "raw": {
-          "type": "float"
-        },
-        "ref_allele": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+        }
+      },
+      "phred": {
+        "type": "float"
+      },
+      "position": {
+        "type": "long"
+      },
+      "raw": {
+        "type": "float"
+      },
+      "ref_allele": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "rs_id": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+        }
+      },
+      "rs_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
-        },
-        "variant_id": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
+        }
+      },
+      "variant_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
         }
       }


### PR DESCRIPTION
- Moves files from [Infrastructure repository](https://github.com/opentargets/infrastructure) that are relevant only to the genetics backend. 
- Updates ElasticSearch to version 7.x
- Makes clickhouse version explicit